### PR TITLE
r10k deploy single environment

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,8 +69,8 @@
 - name: deploy a configuration file for hiera
   template: src=hiera.yaml dest={{puppet_etc_dir}}/hiera.yaml
 
-- name: deploy puppet environments with r10k
-  command: "/usr/local/bin/r10k deploy environment -c {{puppet_etc_dir}}/r10k.yaml -p -v error"
+- name: deploy puppet environment with r10k
+  command: "/usr/local/bin/r10k deploy environment -c {{puppet_etc_dir}}/r10k.yaml -p -v error {{puppet_environment}}"
 
 - name: generate client certificate for puppetmaster
   command: "puppet cert --generate {{hostname}}"


### PR DESCRIPTION
When issuing r10k deploy, deploy specific environment instead of
all possible environments. If no environment is defined, fallback
to production.