### PR TITLE
WIP: Pin r10k version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,7 @@ ruby_gems:
 # workaround: puppet_forge 2.2.7 requires semantic_puppet ~> 1.0 while r10k requires ~> 0.1
 ruby_gems_versions:
   - { gem: 'puppet_forge', version: '2.2.6' }
-  - { gem: 'r10k', version: '' }
+  - { gem: 'r10k', version: '2.2.2' }
   - { gem: 'hiera-eyaml', version: '' }
 
 hiera_private_key: "{{lookup('env','HIERA_PRIVATE_KEY')}}"


### PR DESCRIPTION
r10k depends on cri which has started to depend on
ruby 2.3 in more recent versions.