### PR TITLE
Remove puppet3 support - get puppet4 instead!

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,5 @@ Caveats
 
 You **must** set the inventory hostname for the Puppet master to be the same as
 the host's FQDN.
+
+Needs puppetmaster paths to contain puppetlabs: puppet3 is not supported.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,14 +13,10 @@ rpm_packages:
  - puppet
  - puppetserver
  - rubygems
-ruby_gems:
- - r10k
- - hiera-eyaml
 # workaround: puppet_forge 2.2.7 requires semantic_puppet ~> 1.0 while r10k requires ~> 0.1
 ruby_gems_versions:
   - { gem: 'puppet_forge', version: '2.2.6' }
-  - { gem: 'r10k', version: '' }
-  - { gem: 'hiera-eyaml', version: '' }
+  - { gem: 'r10k', version: '2.2.2' }
 
 hiera_private_key: "{{lookup('env','HIERA_PRIVATE_KEY')}}"
 hiera_public_key: "{{lookup('env','HIERA_PUBLIC_KEY')}}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ rpm_packages:
  - git
  - puppet
  - puppetserver
+ - puppetdb-terminus
  - rubygems
 # workaround: puppet_forge 2.2.7 requires semantic_puppet ~> 1.0 while r10k requires ~> 0.1
 ruby_gems_versions:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 puppet_username: 'puppet'
-puppet_etc_dir: '/etc/puppet'
+puppet_etc_dir: '/etc/puppetlabs/puppet'
+puppet_code_dir: '/etc/puppetlabs/code'
 puppet_data_dir: '/var/lib/puppet'
 hiera_credentials_dir: "{{puppet_etc_dir}}/keys"
 puppet_environment: 'production'
@@ -10,7 +11,7 @@ passenger_dot_repo_file_url: 'https://oss-binaries.phusionpassenger.com/yum/defi
 rpm_packages:
  - git
  - puppet
- - puppet-server
+ - puppetserver
  - rubygems
 ruby_gems:
  - r10k

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,8 @@ hiera_private_key_file: "{{hiera_credentials_dir}}/private_key.pkcs7.pem"
 hiera_public_key_file: "{{hiera_credentials_dir}}/public_key.pkcs7.pem"
 
 puppetmaster_ca_privkey: "{{lookup('env','PUPPETMASTER_CA_PRIVKEY')}}"
+puppetmaster_ca_pubkey: "{{lookup('env','PUPPETMASTER_CA_PUBKEY')}}"
 puppetmaster_ca_cert: "{{lookup('env','PUPPETMASTER_CA_CERT')}}"
 puppetmaster_ca_privkey_file: "{{puppet_data_dir}}/ssl/ca/ca_key.pem"
+puppetmaster_ca_pubkey_file: "{{puppet_data_dir}}/ssl/ca/ca_pub.pem"
 puppetmaster_ca_cert_file: "{{puppet_data_dir}}/ssl/ca/ca_crt.pem"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ puppet_data_dir: '/var/lib/puppet'
 hiera_credentials_dir: "{{puppet_etc_dir}}/keys"
 puppet_environment: 'production'
 hostname: "{{ inventory_hostname }}"
-puppetlabs_repo_url: 'https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm'
+puppetlabs_repo_url: 'https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm'
 passenger_dot_repo_file_url: 'https://oss-binaries.phusionpassenger.com/yum/definitions/el-passenger.repo'
 rpm_packages:
  - git
@@ -28,8 +28,6 @@ hiera_private_key_file: "{{hiera_credentials_dir}}/private_key.pkcs7.pem"
 hiera_public_key_file: "{{hiera_credentials_dir}}/public_key.pkcs7.pem"
 
 puppetmaster_ca_privkey: "{{lookup('env','PUPPETMASTER_CA_PRIVKEY')}}"
-puppetmaster_ca_pubkey: "{{lookup('env','PUPPETMASTER_CA_PUBKEY')}}"
 puppetmaster_ca_cert: "{{lookup('env','PUPPETMASTER_CA_CERT')}}"
 puppetmaster_ca_privkey_file: "{{puppet_data_dir}}/ssl/ca/ca_key.pem"
-puppetmaster_ca_pubkey_file: "{{puppet_data_dir}}/ssl/ca/ca_pub.pem"
 puppetmaster_ca_cert_file: "{{puppet_data_dir}}/ssl/ca/ca_crt.pem"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -103,3 +103,8 @@
   command: "/opt/puppetlabs/bin/puppet apply --environment {{puppet_environment}} --pluginsync --hiera_config {{puppet_etc_dir}}/hiera.yaml --modulepath {{puppet_code_dir}}/environments/{{puppet_environment}}/modules {{puppet_code_dir}}/environments/{{puppet_environment}}/manifests"
   register: puppet_result
   failed_when: (puppet_result.rc != 2) and (puppet_result.rc != 0)
+
+- name: puppet agent to configure the puppetmaster
+  command: "/opt/puppetlabs/bin/puppet agent -t"
+  register: reg_puppet_agent_result
+  failed_when: (reg_puppet_agent_result.rc != 2) and (reg_puppet_agent_result.rc != 0)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -89,13 +89,13 @@
   shell: /opt/puppetlabs/server/bin/puppetserver gem install hiera-eyaml
   when: not ansible_check_mode and gem_list_eyaml.rc != 0 and yum_proxy is not defined
 
-- name: generate client certificate for puppetmaster
+- name: generate client certificate for puppetmaster on bootstrap
   command: "/opt/puppetlabs/bin/puppet cert --generate {{hostname}}"
-  when: puppet_configured is failed
+  when: not puppet_configured.stat.exists
 
-- name: ignite CA directory
+- name: ignite CA directory on bootstrap
   command: "/opt/puppetlabs/bin/puppet cert list -a"
-  when: puppet_configured is failed
+  when: not puppet_configured.stat.exists
 
 - name: run masterless puppet to configure the puppetmaster
   command: "/opt/puppetlabs/bin/puppet apply --environment {{puppet_environment}} --pluginsync --hiera_config {{puppet_etc_dir}}/hiera.yaml --modulepath {{puppet_code_dir}}/environments/{{puppet_environment}}/modules {{puppet_code_dir}}/environments/{{puppet_environment}}/manifests"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,24 +66,28 @@
 - name: deploy puppet environment with r10k
   command: "/usr/local/bin/r10k deploy environment -c {{puppet_etc_dir}}/r10k.yaml -p -v error {{puppet_environment}}"
 
-- shell: rm -Rf /etc/puppetlabs/code/modules
-- shell: ln -s {{puppet_code_dir}}/environments/{{puppet_environment}}/modules /etc/puppetlabs/code/modules
-  ignore_errors: True
-- lineinfile:
+- name: put puppet4 binaries to root's PATH
+  lineinfile:
     dest: /root/.bashrc
     insertafter: EOF
     line: PATH=$PATH:/opt/puppetlabs/bin
+
+- shell: rm -Rf /etc/puppetlabs/code/modules
+- shell: ln -s {{puppet_code_dir}}/environments/{{puppet_environment}}/modules /etc/puppetlabs/code/modules
+  ignore_errors: True
 - shell: "mkdir {{puppet_code_dir}}/environments/production"
   ignore_errors: True
 - shell: "ln -s /etc/puppetlabs/puppet /etc/puppet"
   ignore_errors: True
-- shell: /opt/puppetlabs/puppet/bin/gem install hiera-eyaml
+
+- name: try hiera-eyaml gem install without proxy
+  shell: /opt/puppetlabs/puppet/bin/gem install hiera-eyaml
   ignore_errors: True
-- name: check puppetserver gem
+- name: check hiera-eyaml gem
   shell: /opt/puppetlabs/server/bin/puppetserver gem list | grep hiera-eyaml
   register: gem_list_eyaml
   ignore_errors: True
-- name: install hiera-eyaml if puppetserver gem list does not find it with proxy if defined
+- name: install hiera-eyaml with proxy defined if puppetserver gem list does not find
   command: "/opt/puppetlabs/server/bin/puppetserver gem install hiera-eyaml -p {{ yum_proxy }}"
   when: gem_list_eyaml.rc != 0 and yum_proxy is defined
   ignore_errors: True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,7 @@
   yum: name={{item}} state=present
   with_items: "{{rpm_packages}}"
 
+# workaround: puppet_forge 2.2.7 requires semantic_puppet ~> 1.0 while r10k requires ~> 0.1
 - name: install ruby gems
   gem: name="{{item.gem}}" state=present user_install=no version="{{item.version}}"
   with_items: "{{ruby_gems_versions}}"
@@ -65,24 +66,6 @@
 - name: deploy puppet environment with r10k
   command: "/usr/local/bin/r10k deploy environment -c {{puppet_etc_dir}}/r10k.yaml -p -v error {{puppet_environment}}"
 
-- name: modify puppetdb manage_firewall setting
-  blockinfile:
-    path: "{{puppet_code_dir}}/environments/{{puppet_environment}}/modules/cccp/manifests/role/puppetmaster.pp"
-    insertbefore: java_args
-    marker: "# {mark} ANSIBLE MANAGED BLOCK ONE"
-    block: |2
-        manage_firewall => false,
-- name: add invocation to modules which configure puppetserver
-  blockinfile:
-    path: "{{puppet_code_dir}}/environments/{{puppet_environment}}/modules/cccp/manifests/role/puppetmaster.pp"
-    insertbefore: "class { 'opsviewagent"
-    marker: "# {mark} ANSIBLE MANAGED BLOCK TWO"
-    block: |2
-        class { 'puppetserver::repository': } ->
-        class { 'puppetserver': }
-
-- shell: 'sed -i "/puppet::master/,+5d" {{puppet_code_dir}}/environments/{{puppet_environment}}/modules/cccp/manifests/role/puppetmaster.pp'
-  ignore_errors: True
 - shell: rm -Rf /etc/puppetlabs/code/modules
 - shell: ln -s {{puppet_code_dir}}/environments/{{puppet_environment}}/modules /etc/puppetlabs/code/modules
   ignore_errors: True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   template: src=ssh_config dest=/root/.ssh/config owner=root group=root mode=0600
 
 - name: check if puppet is already configured
-  command: "ls /etc/puppet/rack/public"
+  command: "ls {{puppet_etc_dir}}"
   register: puppet_configured
   ignore_errors: True
 
@@ -22,10 +22,9 @@
   yum: name={{item}} state=present
   with_items: "{{rpm_packages}}"
 
-# workaround: puppet_forge 2.2.7 requires semantic_puppet ~> 1.0 while r10k requires ~> 0.1
 - name: install ruby gems
-  gem: name="{{item.gem}}" state=present user_install=no version="{{item.version}}"
-  with_items: "{{ruby_gems_versions}}"
+  gem: name={{item}} state=present user_install=no
+  with_items: "{{ruby_gems}}"
 
 - name: deploy basic puppet.conf for initial bootstrapping
   template: src=puppet.conf dest={{puppet_etc_dir}}/puppet.conf
@@ -72,6 +71,49 @@
 - name: deploy puppet environment with r10k
   command: "/usr/local/bin/r10k deploy environment -c {{puppet_etc_dir}}/r10k.yaml -p -v error {{puppet_environment}}"
 
+- name: modify puppetdb manage_firewall setting
+  blockinfile:
+    path: "{{puppet_code_dir}}/environments/{{puppet_environment}}/modules/cccp/manifests/role/puppetmaster.pp"
+    insertbefore: java_args
+    marker: "#one"
+    block: |2
+        manage_firewall => false,
+- name: add invocation to modules which configure puppetserver
+  blockinfile:
+    path: "{{puppet_code_dir}}/environments/{{puppet_environment}}/modules/cccp/manifests/role/puppetmaster.pp"
+    insertbefore: "class { 'opsviewagent"
+    marker: "#two"
+    block: |2
+        class { 'puppetserver::repository': } ->
+        class { 'puppetserver': }
+
+- shell: 'sed -i "/puppet::master/,+5d" {{puppet_code_dir}}/environments/{{puppet_environment}}/modules/cccp/manifests/role/puppetmaster.pp'
+  ignore_errors: True
+- shell: rm -Rf /etc/puppetlabs/code/modules
+- shell: ln -s {{puppet_code_dir}}/environments/{{puppet_environment}}/modules /etc/puppetlabs/code/modules
+  ignore_errors: True
+- shell: ln -s /opt/puppetlabs/bin/facter /usr/local/bin/
+  ignore_errors: True
+- shell: ln -s /opt/puppetlabs/bin/puppet* /usr/local/bin/
+  ignore_errors: True
+- shell: ln -s /opt/puppetlabs/bin/mco /usr/local/bin/
+  ignore_errors: True
+- shell: ln -s /opt/puppetlabs/bin/hiera /usr/local/bin/
+  ignore_errors: True
+- shell: "mkdir {{puppet_code_dir}}/environments/production"
+  ignore_errors: True
+- shell: "ln -s /etc/puppetlabs/puppet /etc/puppet"
+  ignore_errors: True
+- shell: /opt/puppetlabs/puppet/bin/gem install hiera-eyaml
+  ignore_errors: True
+- name: check puppetserver gem
+  shell: puppetserver gem list | grep hiera-eyaml
+  register: gem_list_eyaml
+  ignore_errors: True
+- shell: /opt/puppetlabs/server/bin/puppetserver gem install hiera-eyaml
+  when: gem_list_eyaml.rc != 0
+  ignore_errors: True
+
 - name: generate client certificate for puppetmaster
   command: "puppet cert --generate {{hostname}}"
   when: puppet_configured|failed
@@ -81,6 +123,6 @@
   when: puppet_configured|failed
 
 - name: run masterless puppet to configure the puppetmaster
-  command: "puppet apply --environment {{puppet_environment}} --pluginsync --hiera_config {{puppet_etc_dir}}/hiera.yaml --modulepath {{puppet_etc_dir}}/environments/{{puppet_environment}}/modules {{puppet_etc_dir}}/environments/{{puppet_environment}}/manifests"
+  command: "puppet apply --environment {{puppet_environment}} --pluginsync --hiera_config {{puppet_etc_dir}}/hiera.yaml --modulepath {{puppet_code_dir}}/environments/{{puppet_environment}}/modules {{puppet_code_dir}}/environments/{{puppet_environment}}/manifests"
   register: puppet_result
   failed_when: (puppet_result.rc != 2) and (puppet_result.rc != 0)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,7 +72,7 @@
 # puppetserver manages its own gems, and hiera-eyaml needs to be added
 # to those gems for secrets to get passed properly to agents.
 - name: try hiera-eyaml gem install without proxy
-  shell: /opt/puppetlabs/puppet/bin/puppetserver gem install hiera-eyaml
+  shell: /opt/puppetlabs/server/bin/puppetserver gem install hiera-eyaml
   ignore_errors: True
 - name: check hiera-eyaml gem
   shell: /opt/puppetlabs/server/bin/puppetserver gem list | grep hiera-eyaml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,14 +75,14 @@
   blockinfile:
     path: "{{puppet_code_dir}}/environments/{{puppet_environment}}/modules/cccp/manifests/role/puppetmaster.pp"
     insertbefore: java_args
-    marker: "#one"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK ONE"
     block: |2
         manage_firewall => false,
 - name: add invocation to modules which configure puppetserver
   blockinfile:
     path: "{{puppet_code_dir}}/environments/{{puppet_environment}}/modules/cccp/manifests/role/puppetmaster.pp"
     insertbefore: "class { 'opsviewagent"
-    marker: "#two"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK TWO"
     block: |2
         class { 'puppetserver::repository': } ->
         class { 'puppetserver': }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,7 +72,12 @@
   command: "/opt/puppetlabs/bin/puppet generate types --environment {{ puppet_environment }}"
 
 - name: ensure puppet can create the modules directory
-  shell: chown -R puppet:puppet /etc/puppetlabs/code
+  file:
+    path: "{{ puppet_code_dir }}"
+    owner: "{{ puppet_username }}"
+    group: "{{ puppet_username }}"
+    recurse: yes
+    state: directory
 
 # puppetserver manages its own gems, and hiera-eyaml needs to be added to those gems for secrets to get passed properly to agents.
 - name: list puppetserver gems and grep for hiera-eyaml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,9 @@
   template: src=puppet.conf dest={{puppet_etc_dir}}/puppet.conf
   when: puppet_configured is failed or puppet_conf_configured is failed
 
+- name: deploy basic puppetdb.conf for initial bootstrapping
+  template: src=puppetdb.conf dest={{puppet_etc_dir}}/puppetdb.conf
+
 - name: ensure hiera keys directory exists
   file: path="{{hiera_credentials_dir}}" state=directory
         group={{puppet_username}} owner={{puppet_username}} mode=0750

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -93,14 +93,14 @@
   ignore_errors: True
 
 - name: generate client certificate for puppetmaster
-  command: "puppet cert --generate {{hostname}}"
+  command: "/opt/puppetlabs/bin/puppet cert --generate {{hostname}}"
   when: puppet_configured|failed
 
 - name: ignite CA directory
-  command: "puppet cert list -a"
+  command: "/opt/puppetlabs/bin/puppet cert list -a"
   when: puppet_configured|failed
 
 - name: run masterless puppet to configure the puppetmaster
-  command: "puppet apply --environment {{puppet_environment}} --pluginsync --hiera_config {{puppet_etc_dir}}/hiera.yaml --modulepath {{puppet_code_dir}}/environments/{{puppet_environment}}/modules {{puppet_code_dir}}/environments/{{puppet_environment}}/manifests"
+  command: "/opt/puppetlabs/bin/puppet apply --environment {{puppet_environment}} --pluginsync --hiera_config {{puppet_etc_dir}}/hiera.yaml --modulepath {{puppet_code_dir}}/environments/{{puppet_environment}}/modules {{puppet_code_dir}}/environments/{{puppet_environment}}/manifests"
   register: puppet_result
   failed_when: (puppet_result.rc != 2) and (puppet_result.rc != 0)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,14 +69,10 @@
 - shell: rm -Rf /etc/puppetlabs/code/modules
 - shell: ln -s {{puppet_code_dir}}/environments/{{puppet_environment}}/modules /etc/puppetlabs/code/modules
   ignore_errors: True
-- shell: ln -s /opt/puppetlabs/bin/facter /usr/local/bin/
-  ignore_errors: True
-- shell: ln -s /opt/puppetlabs/bin/puppet* /usr/local/bin/
-  ignore_errors: True
-- shell: ln -s /opt/puppetlabs/bin/mco /usr/local/bin/
-  ignore_errors: True
-- shell: ln -s /opt/puppetlabs/bin/hiera /usr/local/bin/
-  ignore_errors: True
+- lineinfile:
+    dest: /root/.bashrc
+    insertafter: EOF
+    line: PATH=$PATH:/opt/puppetlabs/bin
 - shell: "mkdir {{puppet_code_dir}}/environments/production"
   ignore_errors: True
 - shell: "ln -s /etc/puppetlabs/puppet /etc/puppet"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,7 +86,7 @@
   ignore_errors: True
 - name: install hiera-eyaml with proxy defined if puppetserver gem list did not find it
   command: "/opt/puppetlabs/server/bin/puppetserver gem install hiera-eyaml -p {{ yum_proxy }}"
-  when: gem_list_eyaml.rc != 0 and yum_proxy is defined
+  when: gem_list_eyaml.rc != 0 and yum_proxy is defined and not ansible_check_mode
 
 - name: generate client certificate for puppetmaster
   command: "/opt/puppetlabs/bin/puppet cert --generate {{hostname}}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,11 +7,6 @@
   register: puppet_configured
   ignore_errors: True
 
-- name: check if puppet.conf is OK
-  command: "grep -c 'server = ' {{puppet_etc_dir}}/puppet.conf"
-  register: puppet_conf_configured
-  ignore_errors: True
-
 - name: install puppetlabs repo
   yum: name={{item}} state=present
   with_items:
@@ -27,7 +22,6 @@
 
 - name: deploy basic puppet.conf for initial bootstrapping
   template: src=puppet.conf dest={{puppet_etc_dir}}/puppet.conf
-  when: puppet_configured is failed or puppet_conf_configured is failed
 
 - name: deploy basic puppetdb.conf for initial bootstrapping
   template: src=puppetdb.conf dest={{puppet_etc_dir}}/puppetdb.conf
@@ -80,16 +74,19 @@
   shell: chown -R puppet:puppet /etc/puppetlabs/code
 
 # puppetserver manages its own gems, and hiera-eyaml needs to be added to those gems for secrets to get passed properly to agents.
-- name: try hiera-eyaml gem install without proxy - timeout after 1min
-  shell: timeout 1m /opt/puppetlabs/server/bin/puppetserver gem install hiera-eyaml
-  ignore_errors: True
-- name: check hiera-eyaml gem
+- name: list puppetserver gems and grep for hiera-eyaml
   shell: /opt/puppetlabs/server/bin/puppetserver gem list | grep hiera-eyaml
   register: gem_list_eyaml
   ignore_errors: True
+  changed_when: False
+
 - name: install hiera-eyaml with proxy defined if puppetserver gem list did not find it
   command: "/opt/puppetlabs/server/bin/puppetserver gem install hiera-eyaml -p {{ yum_proxy }}"
   when: not ansible_check_mode and gem_list_eyaml.rc != 0 and yum_proxy is defined
+
+- name: try hiera-eyaml gem install without proxy if proxy is not defined
+  shell: /opt/puppetlabs/server/bin/puppetserver gem install hiera-eyaml
+  when: not ansible_check_mode and gem_list_eyaml.rc != 0 and yum_proxy is not defined
 
 - name: generate client certificate for puppetmaster
   command: "/opt/puppetlabs/bin/puppet cert --generate {{hostname}}"
@@ -108,3 +105,4 @@
   command: "/opt/puppetlabs/bin/puppet agent -t"
   register: reg_puppet_agent_result
   failed_when: (reg_puppet_agent_result.rc != 2) and (reg_puppet_agent_result.rc != 0)
+  when: ansible_connection != 'chroot'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,6 +70,9 @@
 - name: deploy puppet environment with r10k
   command: "/usr/local/bin/r10k deploy environment -c {{puppet_etc_dir}}/r10k.yaml -p -v error {{puppet_environment}}"
 
+- name: generate types for the environments to prevent autoload issues
+  command: "/opt/puppetlabs/bin/puppet generate types --environment {{ puppet_environment }}"
+
 - name: ensure puppet can create the modules directory
   shell: chown -R puppet:puppet /etc/puppetlabs/code
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,8 +2,9 @@
 - name: set ssh config for root user
   template: src=ssh_config dest=/root/.ssh/config owner=root group=root mode=0600
 
-- name: check if puppet is already configured
-  command: "ls {{puppet_etc_dir}}"
+- name: stat path for puppet_etc_dir - used check if puppet is already configured
+  stat: 
+    path: "{{puppet_etc_dir}}"
   register: puppet_configured
   ignore_errors: True
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,8 +23,8 @@
   with_items: "{{rpm_packages}}"
 
 - name: install ruby gems
-  gem: name={{item}} state=present user_install=no
-  with_items: "{{ruby_gems}}"
+  gem: name="{{item.gem}}" state=present user_install=no version="{{item.version}}"
+  with_items: "{{ruby_gems_versions}}"
 
 - name: deploy basic puppet.conf for initial bootstrapping
   template: src=puppet.conf dest={{puppet_etc_dir}}/puppet.conf

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,12 +12,6 @@
   with_items:
     - "{{puppetlabs_repo_url}}"
 
-- name: install passenger repo
-  get_url: url="{{ passenger_dot_repo_file_url }}" dest=/etc/yum.repos.d/passenger.repo validate_certs=no
-
-- name: install mod_passenger (with a hack to accept the gpg key initially)
-  command: "yum -y install mod_passenger"
-
 - name: install tools packages
   yum: name={{item}} state=present
   with_items: "{{rpm_packages}}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -106,4 +106,4 @@
   command: "/opt/puppetlabs/bin/puppet agent -t"
   register: reg_puppet_agent_result
   failed_when: (reg_puppet_agent_result.rc != 2) and (reg_puppet_agent_result.rc != 0)
-  when: ansible_connection != 'chroot'
+  when: ansible_connection != 'local'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,8 +69,8 @@
   shell: chown -R puppet:puppet /etc/puppetlabs/code
 
 # puppetserver manages its own gems, and hiera-eyaml needs to be added to those gems for secrets to get passed properly to agents.
-- name: try hiera-eyaml gem install without proxy
-  shell: /opt/puppetlabs/server/bin/puppetserver gem install hiera-eyaml
+- name: try hiera-eyaml gem install without proxy - timeout after 1min
+  shell: timeout 1m /opt/puppetlabs/server/bin/puppetserver gem install hiera-eyaml
   ignore_errors: True
 - name: check hiera-eyaml gem
   shell: /opt/puppetlabs/server/bin/puppetserver gem list | grep hiera-eyaml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,17 +69,18 @@
 - name: ensure puppet can create the modules directory
   shell: chown -R puppet:puppet /etc/puppetlabs
 
+# puppetserver manages its own gems, and hiera-eyaml needs to be added
+# to those gems for secrets to get passed properly to agents.
 - name: try hiera-eyaml gem install without proxy
-  shell: /opt/puppetlabs/puppet/bin/gem install hiera-eyaml
+  shell: /opt/puppetlabs/puppet/bin/puppetserver gem install hiera-eyaml
   ignore_errors: True
 - name: check hiera-eyaml gem
   shell: /opt/puppetlabs/server/bin/puppetserver gem list | grep hiera-eyaml
   register: gem_list_eyaml
   ignore_errors: True
-- name: install hiera-eyaml with proxy defined if puppetserver gem list does not find
+- name: install hiera-eyaml with proxy defined if puppetserver gem list did not find it
   command: "/opt/puppetlabs/server/bin/puppetserver gem install hiera-eyaml -p {{ yum_proxy }}"
   when: gem_list_eyaml.rc != 0 and yum_proxy is defined
-  ignore_errors: True
 
 - name: generate client certificate for puppetmaster
   command: "/opt/puppetlabs/bin/puppet cert --generate {{hostname}}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,13 +72,8 @@
     insertafter: EOF
     line: PATH=$PATH:/opt/puppetlabs/bin
 
-- shell: rm -Rf /etc/puppetlabs/code/modules
-- shell: ln -s {{puppet_code_dir}}/environments/{{puppet_environment}}/modules /etc/puppetlabs/code/modules
-  ignore_errors: True
-- shell: "mkdir {{puppet_code_dir}}/environments/production"
-  ignore_errors: True
-- shell: "ln -s /etc/puppetlabs/puppet /etc/puppet"
-  ignore_errors: True
+- name: ensure puppet can create the modules directory
+  shell: chown -R puppet:puppet /etc/puppetlabs
 
 - name: try hiera-eyaml gem install without proxy
   shell: /opt/puppetlabs/puppet/bin/gem install hiera-eyaml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,11 @@
   register: puppet_configured
   ignore_errors: True
 
+- name: check if puppet.conf is OK
+  command: "grep -c 'server = ' {{puppet_etc_dir}}/puppet.conf"
+  register: puppet_conf_configured
+  ignore_errors: True
+
 - name: install puppetlabs repo
   yum: name={{item}} state=present
   with_items:
@@ -22,7 +27,7 @@
 
 - name: deploy basic puppet.conf for initial bootstrapping
   template: src=puppet.conf dest={{puppet_etc_dir}}/puppet.conf
-  when: puppet_configured is failed
+  when: puppet_configured is failed or puppet_conf_configured is failed
 
 - name: ensure hiera keys directory exists
   file: path="{{hiera_credentials_dir}}" state=directory

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,12 +66,6 @@
 - name: deploy puppet environment with r10k
   command: "/usr/local/bin/r10k deploy environment -c {{puppet_etc_dir}}/r10k.yaml -p -v error {{puppet_environment}}"
 
-- name: put puppet4 binaries to root's PATH
-  lineinfile:
-    dest: /root/.bashrc
-    insertafter: EOF
-    line: PATH=$PATH:/opt/puppetlabs/bin
-
 - name: ensure puppet can create the modules directory
   shell: chown -R puppet:puppet /etc/puppetlabs
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -107,11 +107,12 @@
 - shell: /opt/puppetlabs/puppet/bin/gem install hiera-eyaml
   ignore_errors: True
 - name: check puppetserver gem
-  shell: puppetserver gem list | grep hiera-eyaml
+  shell: /opt/puppetlabs/server/bin/puppetserver gem list | grep hiera-eyaml
   register: gem_list_eyaml
   ignore_errors: True
-- shell: /opt/puppetlabs/server/bin/puppetserver gem install hiera-eyaml
-  when: gem_list_eyaml.rc != 0
+- name: install hiera-eyaml if puppetserver gem list does not find it with proxy if defined
+  command: "/opt/puppetlabs/server/bin/puppetserver gem install hiera-eyaml -p {{ yum_proxy }}"
+  when: gem_list_eyaml.rc != 0 and yum_proxy is defined
   ignore_errors: True
 
 - name: generate client certificate for puppetmaster

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,6 @@
   yum: name={{item}} state=present
   with_items: "{{rpm_packages}}"
 
-# workaround: puppet_forge 2.2.7 requires semantic_puppet ~> 1.0 while r10k requires ~> 0.1
 - name: install ruby gems
   gem: name="{{item.gem}}" state=present user_install=no version="{{item.version}}"
   with_items: "{{ruby_gems_versions}}"
@@ -67,10 +66,9 @@
   command: "/usr/local/bin/r10k deploy environment -c {{puppet_etc_dir}}/r10k.yaml -p -v error {{puppet_environment}}"
 
 - name: ensure puppet can create the modules directory
-  shell: chown -R puppet:puppet /etc/puppetlabs
+  shell: chown -R puppet:puppet /etc/puppetlabs/code
 
-# puppetserver manages its own gems, and hiera-eyaml needs to be added
-# to those gems for secrets to get passed properly to agents.
+# puppetserver manages its own gems, and hiera-eyaml needs to be added to those gems for secrets to get passed properly to agents.
 - name: try hiera-eyaml gem install without proxy
   shell: /opt/puppetlabs/server/bin/puppetserver gem install hiera-eyaml
   ignore_errors: True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,7 +86,7 @@
   ignore_errors: True
 - name: install hiera-eyaml with proxy defined if puppetserver gem list did not find it
   command: "/opt/puppetlabs/server/bin/puppetserver gem install hiera-eyaml -p {{ yum_proxy }}"
-  when: gem_list_eyaml.rc != 0 and yum_proxy is defined and not ansible_check_mode
+  when: not ansible_check_mode and gem_list_eyaml.rc != 0 and yum_proxy is defined
 
 - name: generate client certificate for puppetmaster
   command: "/opt/puppetlabs/bin/puppet cert --generate {{hostname}}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
 
 - name: deploy basic puppet.conf for initial bootstrapping
   template: src=puppet.conf dest={{puppet_etc_dir}}/puppet.conf
-  when: puppet_configured|failed
+  when: puppet_configured is failed
 
 - name: ensure hiera keys directory exists
   file: path="{{hiera_credentials_dir}}" state=directory
@@ -82,11 +82,11 @@
 
 - name: generate client certificate for puppetmaster
   command: "/opt/puppetlabs/bin/puppet cert --generate {{hostname}}"
-  when: puppet_configured|failed
+  when: puppet_configured is failed
 
 - name: ignite CA directory
   command: "/opt/puppetlabs/bin/puppet cert list -a"
-  when: puppet_configured|failed
+  when: puppet_configured is failed
 
 - name: run masterless puppet to configure the puppetmaster
   command: "/opt/puppetlabs/bin/puppet apply --environment {{puppet_environment}} --pluginsync --hiera_config {{puppet_etc_dir}}/hiera.yaml --modulepath {{puppet_code_dir}}/environments/{{puppet_environment}}/modules {{puppet_code_dir}}/environments/{{puppet_environment}}/manifests"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,13 +9,14 @@
   ignore_errors: True
 
 - name: install puppetlabs repo
-  yum: name={{item}} state=present
-  with_items:
-    - "{{puppetlabs_repo_url}}"
+  yum:
+    name: "{{puppetlabs_repo_url}}"
+    state: present
 
 - name: install tools packages
-  yum: name={{item}} state=present
-  with_items: "{{rpm_packages}}"
+  yum:
+    name: "{{rpm_packages}}"
+    state: present
 
 - name: install ruby gems
   gem: name="{{item.gem}}" state=present user_install=no version="{{item.version}}"

--- a/templates/hiera.yaml
+++ b/templates/hiera.yaml
@@ -4,18 +4,16 @@
   - eyaml
 
 :hierarchy:
-  - secret/overrides_for_%{::environment}
   - secret/%{::environment}
   - secret/common
   - "hosts/%{::clientcert}"
-  - overrides_for_%{::environment}
   - "%{::environment}"
   - users
   - common
 
 :yaml:
-  :datadir: "{{puppet_etc_dir}}/environments/%{::environment}/hieradata"
+  :datadir: "{{puppet_code_dir}}/environments/%{::environment}/hieradata"
 :eyaml:
-  :datadir: "{{puppet_etc_dir}}/environments/%{::environment}/hieradata"
+  :datadir: "{{puppet_code_dir}}/environments/%{::environment}/hieradata"
   :pkcs7_private_key: "{{hiera_private_key_file}}"
   :pkcs7_public_key:  "{{hiera_public_key_file}}"

--- a/templates/hiera.yaml
+++ b/templates/hiera.yaml
@@ -4,9 +4,11 @@
   - eyaml
 
 :hierarchy:
+  - secret/overrides_for_%{::environment}
   - secret/%{::environment}
   - secret/common
   - "hosts/%{::clientcert}"
+  - overrides_for_%{::environment}
   - "%{::environment}"
   - users
   - common

--- a/templates/hiera.yaml
+++ b/templates/hiera.yaml
@@ -1,4 +1,5 @@
 ---
+# {{ ansible_managed }}
 :backends:
   - yaml
   - eyaml
@@ -19,3 +20,4 @@
   :datadir: "{{puppet_code_dir}}/environments/%{::environment}/hieradata"
   :pkcs7_private_key: "{{hiera_private_key_file}}"
   :pkcs7_public_key:  "{{hiera_public_key_file}}"
+...

--- a/templates/puppet.conf
+++ b/templates/puppet.conf
@@ -1,11 +1,11 @@
 # {{ ansible_managed }}
 [main]
-    server_urls = https://{{ ansible_fqdn }}:8081
+    server_urls = https://{{ inventory_hostname }}:8081
 
 [agent]
-    server = {{ ansible_fqdn }}
+    server = {{ inventory_hostname }}
     environment = {{ puppet_environment }}
-    certname = {{ ansible_fqdn }}
+    certname = {{ inventory_hostname }}
 
 [master]
     environmentpath = $codedir/environments

--- a/templates/puppet.conf
+++ b/templates/puppet.conf
@@ -1,11 +1,6 @@
 [main]
-    #logdir = /var/log/puppet
-    #rundir = /var/run/puppet
-    #ssldir = $vardir/ssl
 
 [agent]
-    #classfile = $vardir/classes.txt
-    #localconfig = $vardir/localconfig
     server = {{ ansible_fqdn }}
     environment = {{ puppet_environment }}
     certname = {{ ansible_fqdn }}

--- a/templates/puppet.conf
+++ b/templates/puppet.conf
@@ -1,5 +1,6 @@
 # {{ ansible_managed }}
 [main]
+    server_urls = https://{{ ansible_fqdn }}:8081
 
 [agent]
     server = {{ ansible_fqdn }}
@@ -8,3 +9,5 @@
 
 [master]
     environmentpath = $codedir/environments
+    storeconfigs = true
+    reports = store,puppetdb

--- a/templates/puppet.conf
+++ b/templates/puppet.conf
@@ -1,3 +1,4 @@
+# {{ ansible_managed }}
 [main]
 
 [agent]

--- a/templates/puppet.conf
+++ b/templates/puppet.conf
@@ -6,9 +6,9 @@
 [agent]
     #classfile = $vardir/classes.txt
     #localconfig = $vardir/localconfig
-    server = {{ puppetmaster_fqdn }}
+    server = {{ ansible_fqdn }}
     environment = {{ puppet_environment }}
-    certname = {{ puppetmaster_fqdn }}
+    certname = {{ ansible_fqdn }}
 
 [master]
     environmentpath = $codedir/environments

--- a/templates/puppet.conf
+++ b/templates/puppet.conf
@@ -1,14 +1,14 @@
 [main]
-    logdir = /var/log/puppet
-    rundir = /var/run/puppet
-    ssldir = $vardir/ssl
+    #logdir = /var/log/puppet
+    #rundir = /var/run/puppet
+    #ssldir = $vardir/ssl
 
 [agent]
-    classfile = $vardir/classes.txt
-    localconfig = $vardir/localconfig
-    server = {{ ansible_fqdn }}
+    #classfile = $vardir/classes.txt
+    #localconfig = $vardir/localconfig
+    server = {{ puppetmaster_fqdn }}
     environment = {{ puppet_environment }}
-    certname = {{ ansible_fqdn }}
+    certname = {{ puppetmaster_fqdn }}
 
 [master]
-    environmentpath = $confdir/environments
+    environmentpath = $codedir/environments

--- a/templates/puppetdb.conf
+++ b/templates/puppetdb.conf
@@ -1,0 +1,3 @@
+# {{ ansible_managed }}
+[main]
+    server_urls = https://{{ ansible_fqdn }}:8081

--- a/templates/puppetdb.conf
+++ b/templates/puppetdb.conf
@@ -1,3 +1,3 @@
 # {{ ansible_managed }}
 [main]
-    server_urls = https://{{ ansible_fqdn }}:8081
+    server_urls = https://{{ inventory_hostname }}:8081

--- a/templates/r10k.yaml
+++ b/templates/r10k.yaml
@@ -1,7 +1,9 @@
 ---
+# {{ ansible_managed }}
 sources:
   puppet:
     remote: "{{ puppet_environments_repo }}"
     basedir: "{{puppet_code_dir}}/environments"
     invalid_branches: correct
 postrun: [ '/bin/bash', '-c', 'for env in $(ls {{puppet_code_dir}}/environments | awk ''$1 !~ /^master$|^test$|^production$/''); do ln -rs {{puppet_code_dir}}/environments/$env/hieradata/development.yaml {{puppet_code_dir}}/environments/$env/hieradata/$env.yaml; ln -rs {{puppet_code_dir}}/environments/$env/hieradata/secret/development.eyaml {{puppet_code_dir}}/environments/$env/hieradata/secret/$env.eyaml; done' ]
+...

--- a/templates/r10k.yaml
+++ b/templates/r10k.yaml
@@ -2,6 +2,6 @@
 sources:
   puppet:
     remote: "{{ puppet_environments_repo }}"
-    basedir: "{{puppet_etc_dir}}/environments"
+    basedir: "{{puppet_code_dir}}/environments"
     invalid_branches: correct
-postrun: [ '/bin/bash', '-c', 'for env in $(ls {{puppet_etc_dir}}/environments | awk ''$1 !~ /^master$|^test$|^production$/''); do ln -rs {{puppet_etc_dir}}/environments/$env/hieradata/development.yaml {{puppet_etc_dir}}/environments/$env/hieradata/$env.yaml; ln -rs {{puppet_etc_dir}}/environments/$env/hieradata/secret/development.eyaml {{puppet_etc_dir}}/environments/$env/hieradata/secret/$env.eyaml; done' ]
+postrun: [ '/bin/bash', '-c', 'for env in $(ls {{puppet_code_dir}}/environments | awk ''$1 !~ /^master$|^test$|^production$/''); do ln -rs {{puppet_code_dir}}/environments/$env/hieradata/development.yaml {{puppet_code_dir}}/environments/$env/hieradata/$env.yaml; ln -rs {{puppet_code_dir}}/environments/$env/hieradata/secret/development.eyaml {{puppet_code_dir}}/environments/$env/hieradata/secret/$env.eyaml; done' ]

--- a/templates/ssh_config
+++ b/templates/ssh_config
@@ -1,3 +1,4 @@
+# {{ ansible_managed }}
 # use hiera rsa key for github repositories
 Host github.com
     User git

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -122,8 +122,8 @@ function test_playbook(){
 }
 function extra_tests(){
 
-    echo "TEST: ls /etc/puppet/*"
-    ls /etc/puppet/
+    echo "TEST: ls /etc/puppetlabs/puppet/*"
+    ls /etc/puppetlabs/puppet/
 
 }
 

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -117,8 +117,8 @@ function test_playbook(){
     ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} ||(echo "first ansible run failed" && exit 2 )
 
 
-    echo "TEST: idempotence test! Same as previous but now grep for changed=0.*failed=0"
-    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} | grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' ) || (echo 'Idempotence test: fail' && exit 1)
+#    echo "TEST: idempotence test! Same as previous but now grep for changed=0.*failed=0"
+#    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} | grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' ) || (echo 'Idempotence test: fail' && exit 1)
 }
 function extra_tests(){
 

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -117,8 +117,8 @@ function test_playbook(){
     ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} ||(echo "first ansible run failed" && exit 2 )
 
 
-#    echo "TEST: idempotence test! Same as previous but now grep for changed=0.*failed=0"
-#    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} || grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' ) || (echo 'Idempotence test: fail' && exit 1)
+    echo "TEST: idempotence test! Same as previous but now grep for changed=0.*failed=0"
+    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} | grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' ) || (echo 'Idempotence test: fail' && exit 1)
 }
 function extra_tests(){
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -14,6 +14,8 @@
    - name: pre testingonly - install ruby gems first because we need eyaml to create keys
      gem: name="{{item.gem}}" state=present user_install=no version="{{ item.version }}"
      with_items: "{{ruby_gems_versions}}"
+   - name: pre testingonly - install hiera-eyaml first because we need them keys
+     gem: name="hiera-eyaml" state=present user_install=no
    - name: pre testingonly - create hiera keys
      command: eyaml createkeys --pkcs7-private-key=credentials/hiera_private_key.pkcs7.pem --pkcs7-public-key=credentials/hiera_public_key.pkcs7.pem
 ...


### PR DESCRIPTION
This is mostly work done by @junousi in use in https://github.com/CSCfi/polte that I have been testing on our normal infrastructure.
Testing:
 - Use this role after deploying a fresh VM to setup a puppetmaster version 4 with collection RPMs. 
 - Use https://github.com/CSCfi/ansible-role-puppetize to puppetize the puppet-agent4.

Merging this makes making changes to the puppet3 code a bit trickier, but one could make another branch for puppet3 from the commit prior to this PR if desired.

 - #CCCP-1278 

Summary of changes:
 - change paths and variables to the new puppetlabs ones
 - pin gems
 - remove passenger code
 - gem install of hiera-eyaml
 - add another scenario where we want to template in puppet.conf
 - add some ansible_managed comments to templates
 - generate types of the puppet_environment - this fixed the "autoload" issues we saw on the first puppet run