### PR TITLE
Identical exit code processing for puppet apply and puppet agent

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -107,9 +107,11 @@
   command: "/opt/puppetlabs/bin/puppet apply --environment {{puppet_environment}} --pluginsync --hiera_config {{puppet_etc_dir}}/hiera.yaml --modulepath {{puppet_code_dir}}/environments/{{puppet_environment}}/modules {{puppet_code_dir}}/environments/{{puppet_environment}}/manifests"
   register: puppet_result
   failed_when: (puppet_result.rc != 2) and (puppet_result.rc != 0)
+  changed_when: puppet_result.rc != 0
 
 - name: puppet agent to configure the puppetmaster
   command: "/opt/puppetlabs/bin/puppet agent -t"
   register: reg_puppet_agent_result
   failed_when: (reg_puppet_agent_result.rc != 2) and (reg_puppet_agent_result.rc != 0)
+  changed_when: reg_puppet_agent_result.rc != 0
   when: ansible_connection != 'local'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -104,14 +104,14 @@
   when: not puppet_configured.stat.exists
 
 - name: run masterless puppet to configure the puppetmaster
-  command: "/opt/puppetlabs/bin/puppet apply --environment {{puppet_environment}} --pluginsync --hiera_config {{puppet_etc_dir}}/hiera.yaml --modulepath {{puppet_code_dir}}/environments/{{puppet_environment}}/modules {{puppet_code_dir}}/environments/{{puppet_environment}}/manifests"
+  command: "/opt/puppetlabs/bin/puppet apply --detailed-exitcodes --environment {{puppet_environment}} --pluginsync --hiera_config {{puppet_etc_dir}}/hiera.yaml --modulepath {{puppet_code_dir}}/environments/{{puppet_environment}}/modules {{puppet_code_dir}}/environments/{{puppet_environment}}/manifests"
   register: puppet_result
   failed_when: (puppet_result.rc != 2) and (puppet_result.rc != 0)
-  changed_when: puppet_result.rc != 0
+  changed_when: (puppet_result.rc >= 2)
 
 - name: puppet agent to configure the puppetmaster
   command: "/opt/puppetlabs/bin/puppet agent -t"
   register: reg_puppet_agent_result
   failed_when: (reg_puppet_agent_result.rc != 2) and (reg_puppet_agent_result.rc != 0)
-  changed_when: reg_puppet_agent_result.rc != 0
+  changed_when: (reg_puppet_agent_result.rc >= 2)
   when: ansible_connection != 'local'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -103,7 +103,7 @@
   command: "/opt/puppetlabs/bin/puppet cert list -a"
   when: not puppet_configured.stat.exists
 
-- name: run masterless puppet to configure the puppetmaster
+- name: run masterless puppet to configure the puppetmaster - NOTE! this will always create a change due to CCCP-2840
   command: "/opt/puppetlabs/bin/puppet apply --detailed-exitcodes --environment {{puppet_environment}} --pluginsync --hiera_config {{puppet_etc_dir}}/hiera.yaml --modulepath {{puppet_code_dir}}/environments/{{puppet_environment}}/modules {{puppet_code_dir}}/environments/{{puppet_environment}}/manifests"
   register: puppet_result
   failed_when: (puppet_result.rc != 2) and (puppet_result.rc != 0)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -107,11 +107,11 @@
   command: "/opt/puppetlabs/bin/puppet apply --detailed-exitcodes --environment {{puppet_environment}} --pluginsync --hiera_config {{puppet_etc_dir}}/hiera.yaml --modulepath {{puppet_code_dir}}/environments/{{puppet_environment}}/modules {{puppet_code_dir}}/environments/{{puppet_environment}}/manifests"
   register: puppet_result
   failed_when: (puppet_result.rc != 2) and (puppet_result.rc != 0)
-  changed_when: (puppet_result.rc >= 2)
+  changed_when: (puppet_result.rc == 2) or (puppet_result.rc == 4) or (puppet_result.rc == 6)
 
 - name: puppet agent to configure the puppetmaster
   command: "/opt/puppetlabs/bin/puppet agent -t"
   register: reg_puppet_agent_result
   failed_when: (reg_puppet_agent_result.rc != 2) and (reg_puppet_agent_result.rc != 0)
-  changed_when: (reg_puppet_agent_result.rc >= 2)
+  changed_when: (reg_puppet_agent_result.rc == 2) or (reg_puppet_agent_result.rc == 4) or (reg_puppet_agent_result.rc == 6)
   when: ansible_connection != 'local'


### PR DESCRIPTION
A "puppet agent --test" automatically uses "--detailed-exitcodes"
according to:

https://puppet.com/docs/puppet/latest/man/apply.html
https://puppet.com/docs/puppet/latest/man/agent.html

This means that "puppet apply" is currently using some different
exit code scheme.

Changes:

- Enforce --detailed-exitcodes also in the puppet apply task
- Add `changed_when` clauses so the tasks behave as expected vs. documentation exit codes
- Add a note about CCCP-2840 to mitigate confusion.
