### PR TITLE
Enable puppetmaster5-devel.epouta to run in Alma8

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,7 +12,7 @@ rpm_packages:
  - git
  - puppet
  - puppetserver
- - puppetdb-terminus
+ - puppetdb-termini
  - rubygems
 # workaround: puppet_forge 2.2.7 requires semantic_puppet ~> 1.0 while r10k requires ~> 0.1
 ruby_gems_versions:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ puppetlabs_repo_url: 'https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noa
 passenger_dot_repo_file_url: 'https://oss-binaries.phusionpassenger.com/yum/definitions/el-passenger.repo'
 rpm_packages:
  - git
- - puppet
+ - puppet-agent
  - puppetserver
  - puppetdb-termini
  - rubygems

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,8 @@
   yum:
     name: "{{rpm_packages}}"
     state: present
+    enablerepo:
+      - puppet5
 
 - name: install ruby gems
   gem: name="{{item.gem}}" state=present user_install=no version="{{item.version}}" executable=/opt/puppetlabs/puppet/bin/gem

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,8 +18,6 @@
   yum:
     name: "{{rpm_packages}}"
     state: present
-    enablerepo:
-      - puppet5
 
 - name: install ruby gems
   gem: name="{{item.gem}}" state=present user_install=no version="{{item.version}}" executable=/opt/puppetlabs/puppet/bin/gem

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,7 @@
   yum:
     name: "{{puppetlabs_repo_url}}"
     state: present
+    disable_gpg_check: yes
 
 - name: install tools packages
   yum:


### PR DESCRIPTION
In centos7 there is no actual "puppet" package installed, but rather "puppet-agent" is installed. Nevertheless yum will not complain if "puppet" is given to it.
In Alma8 there is no "puppet" package available in the first place, hence the replacement with "puppet-agent"

"puppetdb-terminus" is not available in Alma8. Nevertheless the description on "puppetdb-termini" says that "it contains terminus for puppetdb". On a side note, "termini" is the plural of "terminus" in latin, which might hint to the fact that the termini package contains terminus content too