### PR TITLE
Switch puppet5 -> puppet6

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -105,7 +105,7 @@
   when: not puppet_configured.stat.exists
 
 - name: run masterless puppet to configure the puppetmaster - NOTE! this will always create a change due to CCCP-2840
-  command: "/opt/puppetlabs/bin/puppet apply --detailed-exitcodes --environment {{puppet_environment}} --pluginsync --hiera_config {{puppet_etc_dir}}/hiera.yaml --modulepath {{puppet_code_dir}}/environments/{{puppet_environment}}/modules {{puppet_code_dir}}/environments/{{puppet_environment}}/manifests"
+  command: "/opt/puppetlabs/bin/puppet apply --detailed-exitcodes --environment {{puppet_environment}} --hiera_config {{puppet_etc_dir}}/hiera.yaml --modulepath {{puppet_code_dir}}/environments/{{puppet_environment}}/modules {{puppet_code_dir}}/environments/{{puppet_environment}}/manifests"
   register: puppet_result
   failed_when: (puppet_result.rc != 2) and (puppet_result.rc != 0)
   changed_when: (puppet_result.rc == 2) or (puppet_result.rc == 4) or (puppet_result.rc == 6)

--- a/templates/hiera.yaml
+++ b/templates/hiera.yaml
@@ -1,23 +1,47 @@
 ---
 # {{ ansible_managed }}
-:backends:
-  - yaml
-  - eyaml
+version: 5
 
-:hierarchy:
-  - secret/overrides_for_%{::environment}
-  - secret/%{::environment}
-  - secret/common
-  - "hosts/%{::clientcert}"
-  - overrides_for_%{::environment}
-  - "%{::environment}"
-  - users
-  - common
+defaults:
+  datadir: "{{puppet_code_dir}}/environments/%{::environment}/hieradata"
+  data_hash: yaml_data
 
-:yaml:
-  :datadir: "{{puppet_code_dir}}/environments/%{::environment}/hieradata"
-:eyaml:
-  :datadir: "{{puppet_code_dir}}/environments/%{::environment}/hieradata"
-  :pkcs7_private_key: "{{hiera_private_key_file}}"
-  :pkcs7_public_key:  "{{hiera_public_key_file}}"
+#backends:
+#  - yaml
+#  - eyaml
+
+hierarchy:
+  - name: "Secrets in eyaml"
+    lookup_key: eyaml_lookup_key
+    paths:
+      - "secret/overrides_for_%{::environment}.eyaml"
+      - "secret/%{::environment}.eyaml"
+      - "secret/common.eyaml"
+    options:
+      pkcs7_private_key: "{{hiera_private_key_file}}"
+      pkcs7_public_key:  "{{hiera_public_key_file}}"
+  - name: "Other data in yaml"
+    paths:
+      - "hosts/%{::clientcert}.yaml"
+      - "overrides_for_%{::environment}.yaml"
+      - "%{::environment}.yaml"
+      - "users.yaml"
+      - "common.yaml"
+
+#hierarchy:
+#  - secret/overrides_for_%{::environment}
+#  - secret/%{::environment}
+#  - secret/common
+#  - "hosts/%{::clientcert}"
+#  - overrides_for_%{::environment}
+#  - "%{::environment}"
+#  - users
+#  - common
+
+#yaml:
+#  datadir: "{{puppet_code_dir}}/environments/%{::environment}/hieradata"
+#eyaml:
+#  datadir: "{{puppet_code_dir}}/environments/%{::environment}/hieradata"
+#  pkcs7_private_key: "{{hiera_private_key_file}}"
+#  pkcs7_public_key:  "{{hiera_public_key_file}}"
 ...

--- a/templates/hiera.yaml
+++ b/templates/hiera.yaml
@@ -6,10 +6,6 @@ defaults:
   datadir: "{{puppet_code_dir}}/environments/%{::environment}/hieradata"
   data_hash: yaml_data
 
-#backends:
-#  - yaml
-#  - eyaml
-
 hierarchy:
   - name: "Secrets in eyaml"
     lookup_key: eyaml_lookup_key
@@ -27,21 +23,4 @@ hierarchy:
       - "%{::environment}.yaml"
       - "users.yaml"
       - "common.yaml"
-
-#hierarchy:
-#  - secret/overrides_for_%{::environment}
-#  - secret/%{::environment}
-#  - secret/common
-#  - "hosts/%{::clientcert}"
-#  - overrides_for_%{::environment}
-#  - "%{::environment}"
-#  - users
-#  - common
-
-#yaml:
-#  datadir: "{{puppet_code_dir}}/environments/%{::environment}/hieradata"
-#eyaml:
-#  datadir: "{{puppet_code_dir}}/environments/%{::environment}/hieradata"
-#  pkcs7_private_key: "{{hiera_private_key_file}}"
-#  pkcs7_public_key:  "{{hiera_public_key_file}}"
 ...


### PR DESCRIPTION
The main change is the adoption of hiera template version 5, which is mandatory in puppet6